### PR TITLE
Disallow parse_ini_file parsing so that the config doesn't get overwritt...

### DIFF
--- a/litle/sdk/Obj2xml.php
+++ b/litle/sdk/Obj2xml.php
@@ -205,9 +205,9 @@ class Obj2xml
     {
         $config_array = null;
 
-    $ini_file = realpath(dirname(__FILE__)) . '/litle_SDK_config.ini';
+        $ini_file = realpath(dirname(__FILE__)) . '/litle_SDK_config.ini';
         if (file_exists($ini_file)) {
-            @$config_array =parse_ini_file('litle_SDK_config.ini');
+            @$config_array =parse_ini_file('litle_SDK_config.ini', false, INI_SCANNER_RAW);
         }
 
         if (empty($config_array)) {


### PR DESCRIPTION
This will not convert the config values and take them as is. 

By default the parse_ini_file reads the configuration and parse them using the defined variables.