### PR TITLE
Added phpunit composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },
+    "scripts": {
+        "test": "phpunit"
+    },
     "autoload":{
      	"psr-0":{"litle\\sdk" : "."}
     }


### PR DESCRIPTION
`phpunit` was previously registered as a development dependency, but no
`composer` script had been provided to run `phpunit` via `composer`. As
such, it was previously necessary to have `phpunit` globally installed
on the system `$PATH` in order to run the unit-tests.

This commit introduces a `composer` script that runs `phpunit`,
obviating the need for installing `phpunit` globally.